### PR TITLE
Enemy Patrolling Adjustments

### DIFF
--- a/2D Top-Down/Assets/Scenes/SampleScene.unity
+++ b/2D Top-Down/Assets/Scenes/SampleScene.unity
@@ -573,7 +573,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 189447423}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.53, y: -2.27, z: 0}
+  m_LocalPosition: {x: 3.61, y: -1.93, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -715,14 +715,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 249668970}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -2.64, y: -0.19, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1799774219}
   - {fileID: 189447424}
-  m_Father: {fileID: 1119614662}
-  m_RootOrder: -1
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &286049704
 GameObject:
@@ -2998,7 +2998,7 @@ GameObject:
   - component: {fileID: 1119614669}
   - component: {fileID: 1119614670}
   - component: {fileID: 1119614671}
-  - component: {fileID: 1119614672}
+  - component: {fileID: 1119614673}
   m_Layer: 7
   m_Name: Enemy
   m_TagString: Enemy
@@ -3098,7 +3098,6 @@ Transform:
   m_Children:
   - {fileID: 558035609}
   - {fileID: 1911462493}
-  - {fileID: 249668971}
   - {fileID: 624551120}
   m_Father: {fileID: 1114705151}
   m_RootOrder: 0
@@ -3337,7 +3336,7 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.5
---- !u!114 &1119614672
+--- !u!114 &1119614673
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3346,32 +3345,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1119614659}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95aca832ccbc33e4f871ba0acc3d64d9, type: 3}
+  m_Script: {fileID: 11500000, guid: bef994dd9eadee740a0b505287cd529f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  currentState: 0
-  maxHealth: {fileID: 0}
-  health: 0
-  enemyName: 
-  baseAttack: 0
-  moveSpeed: 4
-  target: {fileID: 1799774219}
-  chaseRadius: 0
-  attackRadius: 0
-  homePosition: {fileID: 189447424}
-  anim: {fileID: 0}
-  maxSpeed: 2
-  acceleration: 50
-  deacceleration: 100
-  currentSpeed: 0
-  path:
+  speed: 1.5
+  patrolPoints:
   - {fileID: 1799774219}
   - {fileID: 189447424}
-  currentPoint: 0
-  currentGoal: {fileID: 1799774219}
-  roundingDistance: 4
-  target: {fileID: 0}
-  moveSpeed: 4
+  waitTime: 2
 --- !u!1 &1134484687
 GameObject:
   m_ObjectHideFlags: 0

--- a/2D Top-Down/Assets/Scripts/Enemy/PatrolEnemy.cs
+++ b/2D Top-Down/Assets/Scripts/Enemy/PatrolEnemy.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PatrolEnemy : MonoBehaviour
+{
+
+    public float speed;
+    public Transform[] patrolPoints;
+    public float waitTime;
+    int currentPointIndex;
+    bool once;
+
+    private void Update()
+    {
+        if (transform.position != patrolPoints[currentPointIndex].position)
+        {
+            transform.position = Vector2.MoveTowards(transform.position, patrolPoints[currentPointIndex].position, speed * Time.deltaTime);
+        }
+        else
+        {
+            if ( once == false)
+            {
+                once = true;
+                StartCoroutine(Wait());
+            }
+            
+        }
+        
+    }
+
+    IEnumerator Wait()
+    {
+        yield return new WaitForSeconds(waitTime);
+        if (currentPointIndex + 1 < patrolPoints.Length)
+        {
+            currentPointIndex++;
+        }
+        else
+        {
+            currentPointIndex = 0;
+        }
+        once = false;
+        
+    }
+}

--- a/2D Top-Down/Assets/Scripts/Enemy/PatrolEnemy.cs.meta
+++ b/2D Top-Down/Assets/Scripts/Enemy/PatrolEnemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bef994dd9eadee740a0b505287cd529f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a new enemy patrolling script and adjusted the enemy patrolling points. Now the enemy is able to patrol between different points at a set speed and a set wait time. When the player is within range, the enemy will stop patrolling and begin to chase the player. Once the player is out of range, the enemy will return to its patrol point coordinate. Still needing to fix a bug with the patrolling where the enemy does not avoid obstacles, but instead will run into them and slide to the point it needs to get to.